### PR TITLE
fix: read lambda function data source at plan time

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,21 +397,19 @@ File a GitHub [issue](https://github.com/cloudopsworks/terraform-module-aws-lb-t
 
 
 ## DevOps Tools
-[]()
+[Our Products](https://cloudopsworks.co/products/)
+[CI/CD Blueprint](https://cloudopsworks.co/cicd-blueprint/)
+[Open Source](https://cloudopsworks.co/open-source/)
+
 ## Slack Community
 
 
 ## Newsletter
-
-## Office Hours
-
-## Contributing
+[Resources Directory](https://cloudopsworks.co/resources/)
 
 ### Bug Reports & Feature Requests
 
 Please use the [issue tracker](https://github.com/cloudopsworks/terraform-module-aws-lb-target-group/issues) to report any bugs or file feature requests.
-
-### Developing
 
 
 
@@ -502,4 +500,4 @@ This project is maintained by [Cloud Ops Works LLC][website].
   [share_reddit]: https://reddit.com/submit/?url=https://github.com/cloudopsworks/terraform-module-aws-lb-target-group
   [share_facebook]: https://facebook.com/sharer/sharer.php?u=https://github.com/cloudopsworks/terraform-module-aws-lb-target-group
   [share_email]: mailto:?subject=Terraform+AWS+LB+Target+Group+Module&body=https://github.com/cloudopsworks/terraform-module-aws-lb-target-group
-  [beacon]: https://ga-beacon.cloudospworks.co/G-QMZVYYN2VN/cloudopsworks/terraform-module-aws-lb-target-group?pixel&cs=github&cm=readme&an=terraform-module-aws-lb-target-group
+  [beacon]: https://ga-beacon.cloudopsworks.co/G-QMZVYYN2VN/cloudopsworks/terraform-module-aws-lb-target-group?pixel&cs=github&cm=readme&an=terraform-module-aws-lb-target-group

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 ##
-# (c) 2021-2025
+# (c) 2021-2026
 #     Cloud Ops Works LLC - https://cloudops.works/
 #     Find us on:
 #       GitHub: https://github.com/cloudopsworks
@@ -245,8 +245,7 @@ data "aws_lambda_function" "lambda" {
   for_each = merge([
     for k, v in var.target_groups : {
       for target in try(v.targets, []) : "${k}-${target.target_id}" => {
-        target_group_arn = aws_lb_target_group.this[k].arn
-        target_id        = target.target_id
+        target_id = target.target_id
       } if !startswith(target.target_id, "arn:aws:lambda")
     } if try(v.target_type, "instance") == "lambda"
   ]...)


### PR DESCRIPTION
## Summary

- Remove the target group ARN from the Lambda data source iterator so the lookup depends only on input target definitions.
- Keep target group and Lambda permission dependencies on the resource graph where they belong.
- Refresh the modified Terraform file header to the current project copyright range.

+semver: fix